### PR TITLE
Avoid infinite loop when cycle in hierarchy

### DIFF
--- a/trinidad-api/src/main/java/org/apache/myfaces/trinidad/component/UIXComponentBase.java
+++ b/trinidad-api/src/main/java/org/apache/myfaces/trinidad/component/UIXComponentBase.java
@@ -401,6 +401,8 @@ abstract public class UIXComponentBase extends UIXComponent
 
     // Search for an ancestor that is a naming container
     UIComponent containerComponent = getParent();
+    String origId = (null != containerComponent) ? containerComponent.getId() : null;
+    
     while (null != containerComponent)
     {
       if (containerComponent instanceof NamingContainer)
@@ -420,6 +422,8 @@ abstract public class UIXComponentBase extends UIXComponent
       }
 
       containerComponent = containerComponent.getParent();
+      if (origId != null && origId.equals(containerComponent != null ? containerComponent.getId():null)) 
+        throw new IllegalStateException();
     }
 
     Renderer renderer = getRenderer(context);


### PR DESCRIPTION
In certain cases, cycles in the components hierarchy appear. Due to the current implementation an infinite loop is generated and the thread hogs the CPU. The only option is to kill the JVM.
The proposed change avoids this situation.