### PR TITLE
Fix DateTimeConverter to work fine with resolvers that returns type Object.class always

### DIFF
--- a/trinidad-impl/src/main/java/org/apache/myfaces/trinidadinternal/convert/DateTimeConverter.java
+++ b/trinidad-impl/src/main/java/org/apache/myfaces/trinidadinternal/convert/DateTimeConverter.java
@@ -132,6 +132,16 @@ public class DateTimeConverter extends
       if(expectedType == null || expectedType == Object.class)
       {
         expectedType = expression.getType(context.getELContext());
+        
+        // Some ELResolvers like MapELResolver returns Object always for getType. Check the getValue for this case.
+        if (expectedType == Object.class)
+        {
+            Object val = expression.getValue(context.getELContext());
+            if (val != null)
+            {
+                expectedType = val.getClass();
+            }
+        }
       }
 
       // Sometimes the type might be null, if it cannot be determined:


### PR DESCRIPTION
I am coming from this issue: https://github.com/eclipse-ee4j/el-ri/issues/162

There is one ELResolver named MapELResolver that returns always Object.class for the getType method. I have checked that with el-ri team, and they say that is correct.

But this means DateTimeConverter has problems to get the type of objects stored in map, because it will not enter inside the if:
```
      if ((expectedType != null)
          && (!expectedType.isAssignableFrom(value.getClass())))
      {
```


